### PR TITLE
SOPClass import errors in store examples

### DIFF
--- a/source/netdicom/examples/storescp.py
+++ b/source/netdicom/examples/storescp.py
@@ -10,8 +10,8 @@ python storescp.py -h
 """
 
 import argparse
-from netdicom import AE, StorageSOPClass, VerificationSOPClass, logger_setup, \
-    debug
+from netdicom import AE, logger_setup, debug
+from netdicom.SOPclass import StorageSOPClass, VerificationSOPClass
 from dicom.dataset import Dataset, FileDataset
 import tempfile
 

--- a/source/netdicom/examples/storescu.py
+++ b/source/netdicom/examples/storescu.py
@@ -11,7 +11,8 @@ python storescu.py -h
 """
 import sys
 import argparse
-from netdicom import AE, StorageSOPClass, VerificationSOPClass
+from netdicom import AE
+from netdicom.SOPclass import StorageSOPClass, VerificationSOPClass
 from dicom.UID import ExplicitVRLittleEndian, ImplicitVRLittleEndian, \
     ExplicitVRBigEndian
 from dicom import read_file


### PR DESCRIPTION
Since the SOP imports were removed from __init__.py in 293654deeed0, StorageSOPClass and VerificationSOPClass need to be imported from SOPclass directly.