### PR TITLE
introduce configurable client socket receive timeout

### DIFF
--- a/netdicom/applicationentity.py
+++ b/netdicom/applicationentity.py
@@ -244,6 +244,7 @@ class AE(threading.Thread):
         self.MaxAssociationIdleSeconds = None
         self.ConnectTimeoutSeconds = None
         self.AssociateRequestTimeout = 30
+        self.ClientSocketReceiveTimeout = 30
         threading.Thread.__init__(self, name=self.LocalAE['AET'])
         self.daemon = True
         self.SOPUID = [x for x in self.SupportedSOPClassesAsSCP]
@@ -314,7 +315,7 @@ class AE(threading.Thread):
             if a:
                 # got an incoming connection
                 client_socket, remote_address = self.LocalServerSocket.accept()
-                client_socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVTIMEO, struct.pack('ll',10,0))
+                client_socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVTIMEO, struct.pack('ll',self.ClientSocketReceiveTimeout,0))
                 # create a new association
                 self.Associations.append(Association(self, client_socket))
 


### PR DESCRIPTION
I was getting a "resource temporarily unavailable" error message sometimes over a busy WiFi network. 

This is a low level python socket error which is raised when a non-blocking or blocking socket with a timeout does not receive data in time.

This is assuming the low-level `setsockopt/SO_RCVTIMEO` is equivalent to `socket.settimeout()`.

I found I sometimes needed more than a 10 second timeout when running (say) 30 associations transferring around 20,000 images from 2 hosts.

(BTWRunning on Ubuntu 14.04 seems more reliable than running on windows 8.1 which I'm getting a lot of reliability problems with, now investigating.)

Does this look sensible to you?

Thanks!
Callan

PS: Perhaps the ARTIM timeout should be configurable too unless it's 10 seconds for a reason.
