### PR TITLE
Yield DICOM messages and Statuses for C-GET and C-MOVE operations + infinite loop bugfix

### DIFF
--- a/netdicom/SOPclass.py
+++ b/netdicom/SOPclass.py
@@ -229,10 +229,10 @@ class QueryRetrieveFindSOPClass(QueryRetrieveServiceClass):
                 ans.Identifier, self.transfersyntax.is_implicit_VR,
                 self.transfersyntax.is_little_endian)
             try:
-                status = self.Code2Status(ans.Status.value).Type
+                status = self.Code2Status(ans.Status.value)
             except:
                 status = None
-            if status != 'Pending':
+            if status and status.Type != 'Pending':
                 break
             yield status, d
         yield status, d
@@ -376,11 +376,11 @@ class QueryRetrieveGetSOPClass(QueryRetrieveServiceClass):
             # receive c-store
             msg, id = self.DIMSE.Receive(Wait=True)
             if msg.__class__ == C_GET_ServiceParameters:
-                status = self.Code2Status(msg.Status.value).Type
+                status = self.Code2Status(msg.Status.value)
 
                 yield status,msg
 
-                if status != 'Pending':
+                if status.Type != 'Pending':
                     break # last answer
 
             elif msg.__class__ == C_STORE_ServiceParameters:
@@ -475,11 +475,11 @@ class QueryRetrieveMoveSOPClass(QueryRetrieveServiceClass):
             if not ans:
                 continue
 
-            status = self.Code2Status(ans.Status.value).Type
+            status = self.Code2Status(ans.Status.value)
 
             yield status,ans
 
-            if status != 'Pending':
+            if status and status.Type != 'Pending':
                 break # last answer
 
 
@@ -608,10 +608,10 @@ class ModalityWorklistServiceSOPClass (BasicWorklistServiceClass):
                 ans.Identifier, self.transfersyntax.is_implicit_VR,
                 self.transfersyntax.is_little_endian)
             try:
-                status = self.Code2Status(ans.Status.value).Type
+                status = self.Code2Status(ans.Status.value)
             except:
                 status = None
-            if status != 'Pending':
+            if status and status.Type != 'Pending':
                 break
             yield status, d
         yield status, d

--- a/netdicom/SOPclass.py
+++ b/netdicom/SOPclass.py
@@ -376,12 +376,8 @@ class QueryRetrieveGetSOPClass(QueryRetrieveServiceClass):
             # receive c-store
             msg, id = self.DIMSE.Receive(Wait=True)
             if msg.__class__ == C_GET_ServiceParameters:
-                if self.Code2Status(msg.Status.value).Type == 'Pending':
-                    # pending. intermediate C-GET response
-                    pass
-                else:
-                    # last answer
-                    break
+                status = self.Code2Status(msg.Status.value).Type
+                yield status,msg
             elif msg.__class__ == C_STORE_ServiceParameters:
                 # send c-store response
                 rsp = C_STORE_ServiceParameters()
@@ -474,9 +470,8 @@ class QueryRetrieveMoveSOPClass(QueryRetrieveServiceClass):
             if not ans:
                 continue
             status = self.Code2Status(ans.Status.value).Type
-            if status != 'Pending':
-                break
-            yield status
+
+            yield status,ans
 
     def SCP(self, msg):
         ds = dsutils.decode(msg.Identifier, self.transfersyntax.is_implicit_VR,

--- a/netdicom/SOPclass.py
+++ b/netdicom/SOPclass.py
@@ -377,7 +377,12 @@ class QueryRetrieveGetSOPClass(QueryRetrieveServiceClass):
             msg, id = self.DIMSE.Receive(Wait=True)
             if msg.__class__ == C_GET_ServiceParameters:
                 status = self.Code2Status(msg.Status.value).Type
+
                 yield status,msg
+
+                if status != 'Pending':
+                    break # last answer
+
             elif msg.__class__ == C_STORE_ServiceParameters:
                 # send c-store response
                 rsp = C_STORE_ServiceParameters()
@@ -469,9 +474,14 @@ class QueryRetrieveMoveSOPClass(QueryRetrieveServiceClass):
             ans, id = self.DIMSE.Receive(Wait=False)
             if not ans:
                 continue
+
             status = self.Code2Status(ans.Status.value).Type
 
             yield status,ans
+
+            if status != 'Pending':
+                break # last answer
+
 
     def SCP(self, msg):
         ds = dsutils.decode(msg.Identifier, self.transfersyntax.is_implicit_VR,


### PR DESCRIPTION
This allows the transfer progress and status to be monitored easily, and behaves like the Query counterparts.
