### PR TITLE
annotate SOPClass obj w/ transfersyntax for C-GET

### DIFF
--- a/netdicom/SOPclass.py
+++ b/netdicom/SOPclass.py
@@ -394,6 +394,7 @@ class QueryRetrieveGetSOPClass(QueryRetrieveServiceClass):
                         msg.DataSet, self.transfersyntax.is_implicit_VR,
                         self.transfersyntax.is_little_endian)
                     SOPClass = UID2SOPClass(d.SOPClassUID)
+                    SOPClass.transfersyntax = self.transfersyntax
                     status = self.AE.OnReceiveStore(SOPClass, d)
                 except:
                     # cannot understand


### PR DESCRIPTION
This is required when receiving DICOM images with a C-GET request when the DICOM images have an unknown transfer syntax -- the OnReceiveStore handler can infer this from the SOPClass passed as a parameter and set the file_meta flags.

I'd be happy update the examples to show how to support JPG2000 encoded images, but I'd like the other PRs merged so I can do it from a coherent code base.

Thanks!