### PR TITLE
Kill time

### DIFF
--- a/netdicom/ACSEprovider.py
+++ b/netdicom/ACSEprovider.py
@@ -160,20 +160,20 @@ class ACSEServiceProvider(object):
 
 #    def Receive(self, Wait):
 #        return self.DUL.ReceiveACSE(Wait)
-    def Release(self, Reason):
+    def Release(self, Reason, Timeout=None):
         """Requests the release of the associations and waits for
         confirmation"""
         rel = A_RELEASE_ServiceParameters()
         rel.Reason = Reason
         self.DUL.Send(rel)
-        rsp = self.DUL.Receive(Wait=True)
+        rsp = self.DUL.Receive(Wait=True, Timeout=Timeout)
         return rsp
         # self.DUL.Kill()
 
     def Abort(self):
         """Signifies the abortion of the association."""
         ab = A_ABORT_ServiceParameters()
-        self.DUL.Send(rel)
+        self.DUL.Send(ab)
         time.sleep(0.5)
         # self.DUL.Kill()
 

--- a/netdicom/DIMSEprovider.py
+++ b/netdicom/DIMSEprovider.py
@@ -73,11 +73,16 @@ class DIMSEServiceProvider(object):
                     continue
                 if nxt.__class__ is not P_DATA_ServiceParameters:
                     return None, None
-                if self.message.Decode(self.DUL.Receive(Wait, Timeout)):
+
+                data = self.DUL.Receive(Wait, Timeout)
+                if self.message.Decode(data):
                     tmp = self.message
                     self.message = None
                     logger.debug('Decoded DIMSE message: %s', str(tmp))
                     return tmp.ToParams(), tmp.ID
+
+                if data is None and Timeout is not None:
+                    return None, None
         else:
             cls = self.DUL.Peek().__class__
             if cls not in (type(None), P_DATA_ServiceParameters):

--- a/netdicom/DIMSEprovider.py
+++ b/netdicom/DIMSEprovider.py
@@ -66,23 +66,29 @@ class DIMSEServiceProvider(object):
         if Wait:
             # loop until complete DIMSE message is received
             logger.debug('Entering loop for receiving DIMSE message')
+            start = time.time()
             while 1:
                 time.sleep(0.001)
                 nxt = self.DUL.Peek()
+
                 if nxt is None:
-                    continue
+                    if Timeout is not None and time.time() - start > Timeout:
+                        return None, None
+                    else:
+                        continue
+                else:
+                    start = time.time()
+
                 if nxt.__class__ is not P_DATA_ServiceParameters:
+                    logger.debug('Waiting for P-DATA but received %s', nxt.__class__)
                     return None, None
 
-                data = self.DUL.Receive(Wait, Timeout)
-                if self.message.Decode(data):
+                if self.message.Decode(self.DUL.Receive(Wait, Timeout)):
                     tmp = self.message
                     self.message = None
                     logger.debug('Decoded DIMSE message: %s', str(tmp))
                     return tmp.ToParams(), tmp.ID
 
-                if data is None and Timeout is not None:
-                    return None, None
         else:
             cls = self.DUL.Peek().__class__
             if cls not in (type(None), P_DATA_ServiceParameters):

--- a/netdicom/SOPclass.py
+++ b/netdicom/SOPclass.py
@@ -603,6 +603,9 @@ class ModalityWorklistServiceSOPClass (BasicWorklistServiceClass):
             if not ans:
                 if kill_time is not None and time.time() - start > kill_time:
                     logger.debug("breaking for time")
+                    if self.DIMSE.DUL is not None:
+                        logger.debug("idle_timer_expired: %s", self.DIMSE.DUL.idle_timer_expired())
+                        logger.debug("kill: %s", self.DIMSE.DUL.kill)
                     break
                 else:
                     continue

--- a/netdicom/SOPclass.py
+++ b/netdicom/SOPclass.py
@@ -606,7 +606,7 @@ class ModalityWorklistServiceSOPClass (BasicWorklistServiceClass):
                     if self.DIMSE.DUL is not None:
                         logger.debug("idle_timer_expired: %s", self.DIMSE.DUL.idle_timer_expired())
                         logger.debug("kill: %s", self.DIMSE.DUL.kill)
-                    break
+                    return
                 else:
                     continue
             else:

--- a/netdicom/SOPclass.py
+++ b/netdicom/SOPclass.py
@@ -62,7 +62,7 @@ class VerificationServiceClass(ServiceClass):
 
         self.DIMSE.Send(cecho, self.pcid, self.maxpdulength)
 
-        ans, id = self.DIMSE.Receive(Wait=True, Timeout=kill_time)
+        ans, id = self.DIMSE.Receive(Wait=kill_time is None, Timeout=kill_time)
         return self.Code2Status(ans.Status)
 
     def SCP(self, msg):

--- a/netdicom/SOPclass.py
+++ b/netdicom/SOPclass.py
@@ -63,6 +63,11 @@ class VerificationServiceClass(ServiceClass):
         self.DIMSE.Send(cecho, self.pcid, self.maxpdulength)
 
         ans, id = self.DIMSE.Receive(Wait=kill_time is None, Timeout=kill_time)
+        if ans is None:
+            msg = "Timed out waiting for DIMSE.Receive"
+            logger.error(msg)
+            raise Exception(msg)
+
         return self.Code2Status(ans.Status)
 
     def SCP(self, msg):

--- a/netdicom/SOPclass.py
+++ b/netdicom/SOPclass.py
@@ -55,14 +55,14 @@ class VerificationServiceClass(ServiceClass):
     def __init__(self):
         ServiceClass.__init__(self)
 
-    def SCU(self, id):
+    def SCU(self, id, kill_time=None):
         cecho = C_ECHO_ServiceParameters()
         cecho.MessageID = id
         cecho.AffectedSOPClassUID = self.UID
 
         self.DIMSE.Send(cecho, self.pcid, self.maxpdulength)
 
-        ans, id = self.DIMSE.Receive(Wait=True)
+        ans, id = self.DIMSE.Receive(Wait=True, Timeout=kill_time)
         return self.Code2Status(ans.Status)
 
     def SCP(self, msg):

--- a/netdicom/SOPclass.py
+++ b/netdicom/SOPclass.py
@@ -62,7 +62,7 @@ class VerificationServiceClass(ServiceClass):
 
         self.DIMSE.Send(cecho, self.pcid, self.maxpdulength)
 
-        ans, id = self.DIMSE.Receive(Wait=kill_time is None, Timeout=kill_time)
+        ans, id = self.DIMSE.Receive(Wait=True, Timeout=kill_time)
         if ans is None:
             msg = "Timed out waiting for DIMSE.Receive"
             logger.error(msg)

--- a/netdicom/SOPclass.py
+++ b/netdicom/SOPclass.py
@@ -601,7 +601,14 @@ class ModalityWorklistServiceSOPClass (BasicWorklistServiceClass):
             # wait for c-find responses
             ans, id = self.DIMSE.Receive(Wait=False)
             if not ans:
-                continue
+                if kill_time is not None and time.time() - start > kill_time:
+                    logger.debug("breaking for time")
+                    break
+                else:
+                    continue
+            else:
+                start = time.time()
+
             d = dsutils.decode(
                 ans.Identifier, self.transfersyntax.is_implicit_VR,
                 self.transfersyntax.is_little_endian)
@@ -612,10 +619,6 @@ class ModalityWorklistServiceSOPClass (BasicWorklistServiceClass):
             if status != 'Pending':
                 logger.debug("breaking for status")
                 break
-            if kill_time is not None:
-                if time.time() - start > kill_time:
-                    logger.debug("breaking for time")
-                    break
             yield status, d
         yield status, d
 

--- a/netdicom/SOPclass.py
+++ b/netdicom/SOPclass.py
@@ -602,11 +602,9 @@ class ModalityWorklistServiceSOPClass (BasicWorklistServiceClass):
             ans, id = self.DIMSE.Receive(Wait=False)
             if not ans:
                 if kill_time is not None and time.time() - start > kill_time:
-                    logger.debug("breaking for time")
-                    if self.DIMSE.DUL is not None:
-                        logger.debug("idle_timer_expired: %s", self.DIMSE.DUL.idle_timer_expired())
-                        logger.debug("kill: %s", self.DIMSE.DUL.kill)
-                    return
+                    msg = "Timed out waiting for DIMSE.Receive"
+                    logger.error(msg)
+                    raise Exception(msg)
                 else:
                     continue
             else:
@@ -620,7 +618,6 @@ class ModalityWorklistServiceSOPClass (BasicWorklistServiceClass):
             except:
                 status = None
             if status != 'Pending':
-                logger.debug("breaking for status")
                 break
             yield status, d
         yield status, d

--- a/netdicom/SOPclass.py
+++ b/netdicom/SOPclass.py
@@ -592,9 +592,7 @@ class ModalityWorklistServiceSOPClass (BasicWorklistServiceClass):
                                           self.transfersyntax.is_little_endian)
 
         # send c-find request
-        logger.debug("DIMSE.Send:start")
         self.DIMSE.Send(cfind, self.pcid, self.maxpdulength)
-        logger.debug("DIMSE.Send:done")
         start = time.time()
         while 1:
             time.sleep(0.001)

--- a/netdicom/SOPclass.py
+++ b/netdicom/SOPclass.py
@@ -581,7 +581,7 @@ class ModalityWorklistServiceSOPClass (BasicWorklistServiceClass):
         xrange(0xFF01, 0xFF01 + 1)
     )
 
-    def SCU(self, ds, msgid):
+    def SCU(self, ds, msgid, kill_time=None):
         # build C-FIND primitive
         cfind = C_FIND_ServiceParameters()
         cfind.MessageID = msgid
@@ -593,6 +593,7 @@ class ModalityWorklistServiceSOPClass (BasicWorklistServiceClass):
 
         # send c-find request
         self.DIMSE.Send(cfind, self.pcid, self.maxpdulength)
+        start = time.time()
         while 1:
             time.sleep(0.001)
             # wait for c-find responses
@@ -608,6 +609,9 @@ class ModalityWorklistServiceSOPClass (BasicWorklistServiceClass):
                 status = None
             if status != 'Pending':
                 break
+            if kill_time is not None:
+                if time.time() - start > kill_time:
+                    break
             yield status, d
         yield status, d
 

--- a/netdicom/SOPclass.py
+++ b/netdicom/SOPclass.py
@@ -592,7 +592,9 @@ class ModalityWorklistServiceSOPClass (BasicWorklistServiceClass):
                                           self.transfersyntax.is_little_endian)
 
         # send c-find request
+        logger.debug("DIMSE.Send:start")
         self.DIMSE.Send(cfind, self.pcid, self.maxpdulength)
+        logger.debug("DIMSE.Send:done")
         start = time.time()
         while 1:
             time.sleep(0.001)
@@ -608,9 +610,11 @@ class ModalityWorklistServiceSOPClass (BasicWorklistServiceClass):
             except:
                 status = None
             if status != 'Pending':
+                logger.debug("breaking for status")
                 break
             if kill_time is not None:
                 if time.time() - start > kill_time:
+                    logger.debug("breaking for time")
                     break
             yield status, d
         yield status, d

--- a/netdicom/applicationentity.py
+++ b/netdicom/applicationentity.py
@@ -107,7 +107,7 @@ class Association(threading.Thread):
         #del self.ACSE
 
     def Release(self, reason):
-        self.ACSE.Release(reason)
+        self.ACSE.Release(reason, Timeout=self.AssociateRequestTimeout)
         self.Kill()
 
     def Abort(self, reason):

--- a/netdicom/fsm.py
+++ b/netdicom/fsm.py
@@ -27,7 +27,7 @@ def AE_1(provider):
             provider.RemoteClientSocket.settimeout(provider.ConnectTimeoutSeconds)
         provider.RemoteClientSocket.connect(
             provider.primitive.CalledPresentationAddress)
-        provider.RemoteClientSocket.settimeout(timeout_original)
+        # provider.RemoteClientSocket.settimeout(timeout_original)
     except socket.error:
         # cannot connect
         provider.ToServiceUser.put(None)


### PR DESCRIPTION
I don't totally remember what these changes are but they have been sitting on my personal branch for a while. It encompasses a set of fixes to keep various calls from hanging indefinitely if the network connection drops.

It looks like it:
* introduces concept of `kill_time` that can be used to keep various SCU operations for hanging
* passes around and uses timeout on otherwise blocking calls to keep them from blocking indefinitely.